### PR TITLE
Grunt

### DIFF
--- a/generators/app/templates/.gitignore
+++ b/generators/app/templates/.gitignore
@@ -1,6 +1,7 @@
 ###############
 ### Project ###
 .env
+.cache/
 tmp/
 
 ## Dependencies

--- a/generators/node/templates/gruntfile.js
+++ b/generators/node/templates/gruntfile.js
@@ -20,13 +20,28 @@ function initLoadGruntConfig(grunt) {
 
 function quietGruntNewer(grunt) {
 	const originalHeader = grunt.log.header;
+	const originalWriteLn = grunt.log.writeln;
 
-	grunt.log.header = (message) => {
+	// Cannot use arrow functions here as the this object is incorrect otherwise.
+	grunt.log.header = function (message) {
 		// Only if the header does not start with newer or newer-postrun.
 		if (!/newer(-postrun)?:/.test(message)) {
 			originalHeader.apply(this, arguments);
 		}
-	}
+
+		return this;
+	};
+
+	// Cannot use arrow functions here as the this object is incorrect otherwise.
+	grunt.log.writeln = function (message) {
+		// Only write the message if it is not the text from a grunt-newer task.
+		if (message !== 'No newer files to process.') {
+			originalWriteLn.apply(this, arguments);
+		}
+
+		// Need to return the object as in grunt-legacy-log#writeln.
+		return this;
+	};
 }
 
 module.exports = function (grunt) {

--- a/generators/node/templates/gruntfile.js
+++ b/generators/node/templates/gruntfile.js
@@ -18,7 +18,19 @@ function initLoadGruntConfig(grunt) {
 	loadGruntConfig(grunt, options);
 }
 
+function quietGruntNewer(grunt) {
+	const originalHeader = grunt.log.header;
+
+	grunt.log.header = (message) => {
+		// Only if the header does not start with newer or newer-postrun.
+		if (!/newer(-postrun)?:/.test(message)) {
+			originalHeader.apply(this, arguments);
+		}
+	}
+}
+
 module.exports = function (grunt) {
 	initTimeGrunt(grunt);
 	initLoadGruntConfig(grunt);
+	quietGruntNewer(grunt);
 };

--- a/test/node-server-test.js
+++ b/test/node-server-test.js
@@ -62,15 +62,32 @@ describe('yo kk578:node-server MyNodeServerProject', () => {
 				}
 			});
 		});
+
+		it('should not generate extra devDependencies specific to polymer-app', () => {
+			assert.noFileContent('package.json', /"grunt-babel"/);
+			assert.noFileContent('package.json', /"grunt-bower-task"/);
+			assert.noFileContent('package.json', /"grunt-minify-polymer"/);
+			assert.noFileContent('package.json', /"grunt-sass"/);
+			assert.noFileContent('package.json', /"grunt-vulcanize"/);
+		});
 	});
 
 	describe('Grunt', () => {
+		it('should generate additional grunt configs for node-server', () => {
+			assert.file([
+				'grunt/copy.js',
+				'grunt/express.js',
+				'grunt/newer.js',
+				'grunt/uglify.js',
+				'grunt/watch.js'
+			]);
+		});
+
 		it('should add additional tasks specific to node-server', () => {
 			assert.fileContent('grunt/aliases.js', /serve/);
 			assert.fileContent('grunt/aliases.js', /build:server/);
 			assert.fileContent('grunt/copy.js', /server/);
 			assert.fileContent('grunt/eslint.js', /server/);
-			assert.file('grunt/newer.js');
 			assert.fileContent('grunt/watch.js', /server/);
 		});
 
@@ -85,19 +102,34 @@ describe('yo kk578:node-server MyNodeServerProject', () => {
 			]);
 		});
 
+		it('should not add task configs specific to polymer-app', () => {
+			assert.noFile([
+				'grunt/babel.js',
+				'grunt/minifyPolymer.js',
+				'grunt/minifyPolymerCSS.js',
+				'grunt/sass.js'
+			]);
+		});
+
 		it('should not add tasks specific to polymer-app for Bower', () => {
 			assert.noFileContent('grunt/aliases.js', /build:bower/);
 			assert.noFileContent('grunt/uglify.js', /bower/);
 			assert.noFileContent('grunt/watch.js', /bower/);
 		});
 
-		it('should generate additional grunt configs for node-server', () => {
-			assert.file([
-				'grunt/express.js',
-				'grunt/sync.js',
-				'grunt/uglify.js',
-				'grunt/watch.js'
-			]);
+		it('should not add tasks specific to polymer-app for views', () => {
+			assert.noFileContent('grunt/aliases.js', /build:views/);
+			assert.noFileContent('grunt/eslint.js', /views/);
+			assert.noFileContent('grunt/uglify.js', /views/);
+			assert.noFileContent('grunt/watch.js', /views/);
+			assert.noFileContent('grunt/watch.js', /sass-partials/);
+		});
+
+		it('should not add tasks specific to polymer-app for custom components', () => {
+			assert.noFileContent('grunt/aliases.js', /build:components/);
+			assert.noFileContent('grunt/eslint.js', /components/);
+			assert.noFileContent('grunt/uglify.js', /components/);
+			assert.noFileContent('grunt/watch.js', /components/);
 		});
 	});
 

--- a/test/node-server-test.js
+++ b/test/node-server-test.js
@@ -45,10 +45,11 @@ describe('yo kk578:node-server MyNodeServerProject', () => {
 
 		it('should generate extra devDependencies to package.json', () => {
 			assert.fileContent('package.json', /"browser-sync"/);
-			assert.fileContent('package.json', /"grunt-express-server"/);
+			assert.fileContent('package.json', /"grunt-contrib-copy"/);
 			assert.fileContent('package.json', /"grunt-contrib-watch"/);
 			assert.fileContent('package.json', /"grunt-contrib-uglify"/);
-			assert.fileContent('package.json', /"grunt-sync"/);
+			assert.fileContent('package.json', /"grunt-express-server"/);
+			assert.fileContent('package.json', /"grunt-newer"/);
 		});
 
 		it('should generate npm-shrinkwrap for uglify-js', () => {
@@ -67,7 +68,9 @@ describe('yo kk578:node-server MyNodeServerProject', () => {
 		it('should add additional tasks specific to node-server', () => {
 			assert.fileContent('grunt/aliases.js', /serve/);
 			assert.fileContent('grunt/aliases.js', /build:server/);
+			assert.fileContent('grunt/copy.js', /server/);
 			assert.fileContent('grunt/eslint.js', /server/);
+			assert.file('grunt/newer.js');
 			assert.fileContent('grunt/watch.js', /server/);
 		});
 

--- a/util/grunt-configs.js
+++ b/util/grunt-configs.js
@@ -8,9 +8,9 @@ function initialise(options) {
 	grunt.eslint = require('./grunt-configs/eslint.js')(options);
 
 	// Node Server
+	grunt.copy = require('./grunt-configs/copy.js')(options);
 	grunt.express = require('./grunt-configs/express.js')(options);
 	grunt.newer = require('./grunt-configs/newer.js')(options);
-	grunt.sync = require('./grunt-configs/sync.js')(options);
 	grunt.uglify = require('./grunt-configs/uglify.js')(options);
 	grunt.watch = require('./grunt-configs/watch.js')(options);
 

--- a/util/grunt-configs.js
+++ b/util/grunt-configs.js
@@ -9,6 +9,7 @@ function initialise(options) {
 
 	// Node Server
 	grunt.express = require('./grunt-configs/express.js')(options);
+	grunt.newer = require('./grunt-configs/newer.js')(options);
 	grunt.sync = require('./grunt-configs/sync.js')(options);
 	grunt.uglify = require('./grunt-configs/uglify.js')(options);
 	grunt.watch = require('./grunt-configs/watch.js')(options);

--- a/util/grunt-configs/aliases.js
+++ b/util/grunt-configs/aliases.js
@@ -20,8 +20,7 @@ module.exports = (options) => {
 		aliases['build:server'] = {
 			description: 'Build task for server files',
 			tasks: [
-				'eslint:server',
-				'uglify:server',
+				'newer:uglify:server',
 				'sync:server'
 			]
 		};
@@ -30,27 +29,27 @@ module.exports = (options) => {
 			aliases['build:bower'] = {
 				description: 'Build task for bower components',
 				tasks: [
-					'minifyPolymer:bower',
-					'minifyPolymerCSS:bower',
-					'uglify:bower'
+					'newer:minifyPolymer:bower',
+					'newer:minifyPolymerCSS:bower',
+					'newer:uglify:bower'
 				]
 			};
 
 			aliases['build:components'] = {
 				description: 'Build task for custom components',
 				tasks: [
-					'minifyPolymer:components',
-					'sass:components',
-					'uglify:components'
+					'newer:minifyPolymer:components',
+					'newer:sass:components',
+					'newer:uglify:components'
 				]
 			};
 
 			aliases['build:views'] = {
 				description: 'Build task for views',
 				tasks: [
-					'minifyPolymer:views',
-					'sass:views',
-					'uglify:views'
+					'newer:minifyPolymer:views',
+					'newer:sass:views',
+					'newer:uglify:views'
 				]
 			};
 		}

--- a/util/grunt-configs/aliases.js
+++ b/util/grunt-configs/aliases.js
@@ -21,7 +21,7 @@ module.exports = (options) => {
 			description: 'Build task for server files',
 			tasks: [
 				'newer:uglify:server',
-				'sync:server'
+				'newer:copy:server'
 			]
 		};
 

--- a/util/grunt-configs/copy.js
+++ b/util/grunt-configs/copy.js
@@ -1,13 +1,13 @@
 module.exports = (options) => {
-	const sync = {};
+	const copy = {};
 
 	if (options.nodeServer) {
-		sync.server = {
+		copy.server = {
 			files: {
 				'build/.env': '.env'
 			}
 		};
 	}
 
-	return sync;
+	return copy;
 };

--- a/util/grunt-configs/eslint.js
+++ b/util/grunt-configs/eslint.js
@@ -21,13 +21,15 @@ module.exports = (options) => {
 			files: 'server/**/*.js'
 		};
 
-		eslint.components = {
-			files: ['public/custom-components/**/*.js']
-		};
+		if (options.polymerApp) {
+			eslint.components = {
+				files: ['public/custom-components/**/*.js']
+			};
 
-		eslint.views = {
-			src: ['public/scripts/**/*.js']
-		};
+			eslint.views = {
+				src: ['public/scripts/**/*.js']
+			};
+		}
 	}
 
 	return eslint;

--- a/util/grunt-configs/newer.js
+++ b/util/grunt-configs/newer.js
@@ -1,0 +1,11 @@
+﻿module.exports = (options) => {
+	const newer = {};
+
+	if (options.nodeServer) {
+		newer.options = {
+			cache: '.cache/grunt-newer/'
+		};
+	}
+
+	return newer;
+};

--- a/util/package-json.js
+++ b/util/package-json.js
@@ -41,6 +41,7 @@ function create(options) {
 			'grunt-contrib-uglify': '^2.0.0',
 			'grunt-contrib-watch': '^1.0.0',
 			'grunt-express-server': 'KK578/grunt-express-server',
+			'grunt-newer': '^1.2.0',
 			'grunt-sync': '^0.6.2'
 		});
 

--- a/util/package-json.js
+++ b/util/package-json.js
@@ -38,11 +38,11 @@ function create(options) {
 
 		Object.assign(packageJson.devDependencies, {
 			'browser-sync': '^2.14.0',
+			'grunt-contrib-copy': '^1.0.0',
 			'grunt-contrib-uglify': '^2.0.0',
 			'grunt-contrib-watch': '^1.0.0',
 			'grunt-express-server': 'KK578/grunt-express-server',
-			'grunt-newer': '^1.2.0',
-			'grunt-sync': '^0.6.2'
+			'grunt-newer': '^1.2.0'
 		});
 
 		if (options.polymerApp) {


### PR DESCRIPTION
## Changelog
- Add grunt-newer, improving build times during `watch` task.
  _(Also required for optimal browser-sync reloading)_
- Replace `grunt-sync` with `grunt-contrib-copy`.

Closes #5.
Closes #7.
